### PR TITLE
DVCI-227: Add Content Assertions to Register Health Certificate

### DIFF
--- a/features/registerHealthCertificate.feature
+++ b/features/registerHealthCertificate.feature
@@ -11,6 +11,9 @@ Feature: Register Health Certificate
       # Check that an entry exists in response for each entry in request, in same order
       And I expect a response entry exists for each request entry in same order
       And I expect response should validate against the profile http://profiles.ihe.net/ITI/MHD/StructureDefinition/IHE.MHD.ProvideDocumentBundleResponse
+      And I expect the GET request sent to path /List/1 should return status 200
+      And I expect the GET request sent to path /DocumentReference/1 should return status 200
+      And I expect the GET request sent to path /Patient/1 should return status 200
             
   @RegisterInvalidHealthCertificate-400
   Scenario: Submit Bad Request Register Health Certificate Transaction

--- a/features/registerHealthCertificate.feature
+++ b/features/registerHealthCertificate.feature
@@ -8,10 +8,10 @@ Feature: Register Health Certificate
       And I set json body to the file at ./features/fixtures/registerHealthCertificate/Bundle-ProvideDDCCDocument.json
     When I receive a response
     Then I expect response should have a status 200
+      And I expect response should validate against the profile http://profiles.ihe.net/ITI/MHD/StructureDefinition/IHE.MHD.ProvideDocumentBundleResponse
       # Check that an entry exists in response for each entry in request, in same order
       And I expect a response entry exists for each request entry in same order
-      And I expect response should validate against the profile http://profiles.ihe.net/ITI/MHD/StructureDefinition/IHE.MHD.ProvideDocumentBundleResponse
-      And I expect the GET request sent to each location should return status 200
+      And I expect the GET request sent to each response entry location should have a status 200
             
   @RegisterInvalidHealthCertificate-400
   Scenario: Submit Bad Request Register Health Certificate Transaction

--- a/features/registerHealthCertificate.feature
+++ b/features/registerHealthCertificate.feature
@@ -11,9 +11,7 @@ Feature: Register Health Certificate
       # Check that an entry exists in response for each entry in request, in same order
       And I expect a response entry exists for each request entry in same order
       And I expect response should validate against the profile http://profiles.ihe.net/ITI/MHD/StructureDefinition/IHE.MHD.ProvideDocumentBundleResponse
-      And I expect the GET request sent to path /List/1 should return status 200
-      And I expect the GET request sent to path /DocumentReference/1 should return status 200
-      And I expect the GET request sent to path /Patient/1 should return status 200
+      And I expect the GET request sent to each location should return status 200
             
   @RegisterInvalidHealthCertificate-400
   Scenario: Submit Bad Request Register Health Certificate Transaction

--- a/features/support/sharedSteps.js
+++ b/features/support/sharedSteps.js
@@ -78,13 +78,14 @@ Then(
       }
     );
 
-    responseLocations.forEach(async (location) => {
+    const responsePromises = responseLocations.map(async (location) => {
       const response = await pactum.spec().get(`/${location}`);
-      pactum.expect(response).to.have.status(200);
-      // if (response.statusCode !== 200) {
-      //   throw new Error(`Error locating response at location ${location}`);
-      // }
-      return Promise.resolve();
+      try {
+        pactum.expect(response).should.have.status(200);
+      } catch (e) {
+        throw new Error(e.message);
+      }
     });
+    await Promise.all(responsePromises);
   }
 );

--- a/features/support/sharedSteps.js
+++ b/features/support/sharedSteps.js
@@ -63,6 +63,16 @@ Then(
       const { resourceType } = requestEntry.resource;
       requestResources.push(resourceType);
     });
+
     expect(responseResources).to.have.ordered.members(requestResources);
+  }
+);
+
+// eslint-disable-next-line prefer-arrow-callback
+Then(
+  /I expect the GET request sent to path (.*) should return status (.*)$/,
+  async (path, code) => {
+    const response = await pactum.spec().get(path);
+    pactum.expect(response).should.have.status(parseInt(code, 10));
   }
 );

--- a/features/support/sharedSteps.js
+++ b/features/support/sharedSteps.js
@@ -68,24 +68,16 @@ Then(
 
 // eslint-disable-next-line prefer-arrow-callback
 Then(
-  /I expect the GET request sent to each location should return status 200/,
-  async function () {
+  'I expect the GET request sent to each response entry location should have a status {int}',
+  async function (statusCode) {
     // eslint-disable-next-line no-underscore-dangle
-    const responseLocations = this.spec._response.body.entry.map(
-      (responseEntry) => {
-        const { location } = responseEntry.response;
-        return location;
+    const responsePromises = this.spec._response.body.entry.map(
+      async (entry) => {
+        const { location } = entry.response;
+        const response = await pactum.spec().get(`/${location}`);
+        pactum.expect(response).should.have.status(statusCode);
       }
     );
-
-    const responsePromises = responseLocations.map(async (location) => {
-      const response = await pactum.spec().get(`/${location}`);
-      try {
-        pactum.expect(response).should.have.status(200);
-      } catch (e) {
-        throw new Error(e.message);
-      }
-    });
     await Promise.all(responsePromises);
   }
 );

--- a/test/support/mockConfig.js
+++ b/test/support/mockConfig.js
@@ -211,6 +211,39 @@ const config = {
           body: operationOutcomeRequired,
         },
       },
+      {
+        id: 'retrieveRegisterHealthCertificate-List',
+        strict: false,
+        request: {
+          method: 'GET',
+          path: '/List/1',
+        },
+        response: {
+          status: 200,
+        },
+      },
+      {
+        id: 'retrieveRegisterHealthCertificate-DocumentReference',
+        strict: false,
+        request: {
+          method: 'GET',
+          path: '/DocumentReference/1',
+        },
+        response: {
+          status: 200,
+        },
+      },
+      {
+        id: 'retrieveRegisterHealthCertificate-Patient',
+        strict: false,
+        request: {
+          method: 'GET',
+          path: '/Patient/1',
+        },
+        response: {
+          status: 200,
+        },
+      },
     ]);
   },
 };


### PR DESCRIPTION
This PR completes task [DVCI-227 ](https://jira.mitre.org/browse/DVCI-227) to add content assertions to a valid Register Health Certificate transaction.

A shared step was added to check that content exists at all the response locations. The step "I expect the GET request sent to each location should return status 200" gets all the locations from the response and sends a GET request to each of them. If the results of all the GET requests are 200, the step passes. If at least one GET request sends a status code other than 200, the entire step fails.

Mock interactions were added for the List, DocumentReference, and Patient resources that are stored as a result of the valid Register Health Certificate transaction. These mock interactions are then used in the new shared step.

The step "I expect a response entry exists for each request entry in same order" was also cleaned up to use `.map()`. 